### PR TITLE
[FIX] 전시 등록 프로세스 버그 수정

### DIFF
--- a/ARtique/ARtique/Global/Class/NewExhibition.swift
+++ b/ARtique/ARtique/Global/Class/NewExhibition.swift
@@ -10,17 +10,18 @@ import UIKit
 class NewExhibition {
     static let shared = NewExhibition()
     
-    var artworkCnt: Int?
-    var themeId: Int?
-    var selectedArtwork: [UIImage]?
+    var title: String?
+    var phosterImage: UIImage?
+    var phosterTheme: Int?
+    var description: String?
+    var tag: [Int]?
+    var category: Int?
+    var gallerySize: Int?
+    var galleryTheme: Int?
+    var isPublic: Bool?
+    var artworks: [UIImage]?
     var artworkTitle: [String]?
     var artworkExplain: [String]?
-    var title: String?
-    var categoryId: Int?
-    var phosterId: Int?
-    var exhibitionExplain: String?
-    var tagId: [Int]?
-    var isPublic: Bool?
     
     private init() { }
 }

--- a/ARtique/ARtique/Global/Class/NewExhibition.swift
+++ b/ARtique/ARtique/Global/Class/NewExhibition.swift
@@ -19,6 +19,7 @@ class NewExhibition {
     var gallerySize: Int?
     var galleryTheme: Int?
     var isPublic: Bool?
+    var artworkIndex = [Int]()
     var artworks: [UIImage]?
     var artworkTitle: [String]?
     var artworkExplain: [String]?

--- a/ARtique/ARtique/Global/Extension/Notification+Name.swift
+++ b/ARtique/ARtique/Global/Extension/Notification+Name.swift
@@ -14,4 +14,5 @@ extension Notification.Name {
     static let whenAlbumListBtnSelected = Notification.Name("whenAlbumListBtnSelected")
     static let whenAlbumChanged = Notification.Name("whenAlbumChanged")
     static let whenAllExhibitionBtnSelected = Notification.Name("whenAllExhibitionBtnSelected")
+    static let changeFirstResponder = Notification.Name("changeFirstResponder")
 }

--- a/ARtique/ARtique/Global/Extension/UIScrollView+.swift
+++ b/ARtique/ARtique/Global/Extension/UIScrollView+.swift
@@ -13,9 +13,9 @@ extension UIScrollView {
         self.setContentOffset(topOffset, animated: true)
     }
     
-    func scrollToBottom() {
+    func scrollToBottom(animated: Bool) {
       if self.contentSize.height < self.bounds.size.height { return }
         let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height + contentInset.bottom)
-        self.setContentOffset(bottomOffset, animated: true)
+        self.setContentOffset(bottomOffset, animated: animated)
     }
 }

--- a/ARtique/ARtique/Global/Extension/UIView+.swift
+++ b/ARtique/ARtique/Global/Extension/UIView+.swift
@@ -58,4 +58,15 @@ extension UIView {
         let generator = UIImpactFeedbackGenerator(style: degree)
         generator.impactOccurred()
     }
+    
+    /// view를 담당하는 viewController를 찾는 함수
+    func findViewController() -> UIViewController? {
+        if let nextResponder = self.next as? UIViewController {
+            return nextResponder
+        } else if let nextResponder = self.next as? UIView {
+            return nextResponder.findViewController()
+        } else {
+            return nil
+        }
+    }
 }

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
@@ -50,7 +50,7 @@ extension ArtworkExplainCVC {
     
     func configureCell(index: Int) {
         cellIndex = index
-        image.image = exhibitionModel.selectedArtwork?[index] ?? UIImage()
+        image.image = exhibitionModel.artworks?[index] ?? UIImage()
         titleTextField.text = exhibitionModel.artworkTitle?[index] ?? ""
         contentTextView.text = exhibitionModel.artworkExplain?[index] ?? ""
         contentTextView.setTextViewPlaceholder(postContentPlaceholder)

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 import RxSwift
 import RxCocoa
 
@@ -26,6 +27,7 @@ class ArtworkExplainCVC: UICollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
+        setNotification()
     }
     
     override func prepareForReuse() {
@@ -37,6 +39,7 @@ class ArtworkExplainCVC: UICollectionViewCell {
 extension ArtworkExplainCVC {
     private func configureView() {
         scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
         image.backgroundColor = .black
         titleTextField.setRoundTextField(with: "제목을 입력하세요")
         contentTextView.setRoundTextView()
@@ -89,6 +92,38 @@ extension ArtworkExplainCVC {
     }
 }
 
+// MARK: - Custom Methods
+extension ArtworkExplainCVC {
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+           let baseVC = self.findViewController() as? AddExhibitionVC {
+            let keyboardHeight = keyboardFrame.cgRectValue.height
+            UIView.animate(withDuration: 0.3) {
+                self.scrollView.snp.remakeConstraints {
+                    $0.top.equalTo(baseVC.view.safeAreaLayoutGuide.snp.top).offset(16)
+                    $0.bottom.equalTo(baseVC.view.snp.bottom).offset(-keyboardHeight)
+                }
+                self.layoutIfNeeded()
+            }
+            scrollView.scrollToBottom(animated: true)
+        }
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        UIView.animate(withDuration: 0.3) {
+            self.scrollView.snp.remakeConstraints {
+                $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom)
+            }
+            self.layoutIfNeeded()
+        }
+    }
+}
+
 // MARK: - UITextViewDelegate
 extension ArtworkExplainCVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
@@ -122,7 +157,6 @@ extension ArtworkExplainCVC: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        titleTextField.resignFirstResponder()
         contentTextView.becomeFirstResponder()
         return true
     }

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.swift
@@ -40,6 +40,7 @@ extension ArtworkExplainCVC {
         image.backgroundColor = .black
         titleTextField.setRoundTextField(with: "제목을 입력하세요")
         contentTextView.setRoundTextView()
+        titleTextField.delegate = self
         contentTextView.delegate = self
         indexBase.backgroundColor = .white
         indexBase.layer.cornerRadius = indexBase.frame.height / 2
@@ -51,11 +52,24 @@ extension ArtworkExplainCVC {
     func configureCell(index: Int) {
         cellIndex = index
         image.image = exhibitionModel.artworks?[index] ?? UIImage()
-        titleTextField.text = exhibitionModel.artworkTitle?[index] ?? ""
-        contentTextView.text = exhibitionModel.artworkExplain?[index] ?? ""
+        configureText(title: exhibitionModel.artworkTitle?[index] ?? "",
+                      description: exhibitionModel.artworkExplain?[index] ?? "")
         contentTextView.setTextViewPlaceholder(postContentPlaceholder)
         self.index.text = "\(index + 1)"
         bindText()
+    }
+    
+    private func configureText(title: String, description: String) {
+        titleTextField.textColor
+        = title == titleTextField.placeholder
+        ? .gray2 : .label
+        
+        contentTextView.textColor
+        = description == postContentPlaceholder
+        ? .gray2 : .label
+        
+        titleTextField.text = title
+        contentTextView.text = description
     }
     
     private func bindText() {
@@ -81,6 +95,7 @@ extension ArtworkExplainCVC: UITextViewDelegate {
         guard textView.textColor == .gray2 else { return }
         textView.textColor = .label
         textView.text = ""
+        NotificationCenter.default.post(name: .changeFirstResponder, object: cellIndex)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -97,5 +112,18 @@ extension ArtworkExplainCVC: UITextViewDelegate {
         guard let str = textView.text else { return true }
         let newLength = str.count + text.count - range.length
         return newLength <= textViewMaxCnt + 1
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension ArtworkExplainCVC: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        NotificationCenter.default.post(name: .changeFirstResponder, object: cellIndex)
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        titleTextField.resignFirstResponder()
+        contentTextView.becomeFirstResponder()
+        return true
     }
 }

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.xib
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/ArtworkExplainCVC.xib
@@ -11,86 +11,79 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ArtworkExplainCVC" id="gTV-IL-0wX" customClass="ArtworkExplainCVC" customModule="ARtique" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="300" height="482"/>
+            <rect key="frame" x="0.0" y="0.0" width="300" height="462"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="300" height="482"/>
+                <rect key="frame" x="0.0" y="0.0" width="300" height="462"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E17-rw-cau">
-                        <rect key="frame" x="0.0" y="0.0" width="300" height="482"/>
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="462"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dui-K3-Pga">
-                                <rect key="frame" x="0.0" y="0.0" width="300" height="482"/>
+                                <rect key="frame" x="0.0" y="0.0" width="300" height="473"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Fvc-fi-4hD">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="Fvc-fi-4hD" secondAttribute="height" multiplier="1:1" id="6DX-Rh-uMa"/>
+                                            <constraint firstAttribute="width" constant="300" id="mUq-vf-n7V"/>
+                                            <constraint firstAttribute="height" constant="300" id="nSu-lV-vWs"/>
                                         </constraints>
                                     </imageView>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bDq-NE-jEL">
-                                        <rect key="frame" x="0.0" y="324" width="300" height="40"/>
+                                        <rect key="frame" x="0.0" y="316" width="300" height="40"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="YPF-Uy-QKS"/>
+                                            <constraint firstAttribute="height" constant="40" id="SX1-zB-UWs"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="4dv-2j-TT9">
-                                        <rect key="frame" x="0.0" y="372" width="300" height="110"/>
+                                        <rect key="frame" x="0.0" y="363" width="300" height="110"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="110" id="qG9-aq-fE1"/>
+                                            <constraint firstAttribute="height" constant="110" id="7r9-ML-Sjv"/>
                                         </constraints>
                                         <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YVe-5z-4GD">
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YVe-5z-4GD">
                                         <rect key="frame" x="14" y="14" width="24" height="24"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3NY-7S-6bS">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3NY-7S-6bS">
                                                 <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstItem="3NY-7S-6bS" firstAttribute="leading" secondItem="YVe-5z-4GD" secondAttribute="leading" id="9R0-6R-GY7"/>
-                                            <constraint firstAttribute="trailing" secondItem="3NY-7S-6bS" secondAttribute="trailing" id="JiT-6L-oas"/>
-                                            <constraint firstAttribute="width" constant="24" id="Jn8-U5-JFt"/>
-                                            <constraint firstItem="3NY-7S-6bS" firstAttribute="top" secondItem="YVe-5z-4GD" secondAttribute="top" id="Mb5-fC-hgh"/>
-                                            <constraint firstAttribute="bottom" secondItem="3NY-7S-6bS" secondAttribute="bottom" id="ZRX-2w-EVr"/>
-                                            <constraint firstAttribute="height" constant="24" id="qS8-Jw-UVh"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="bDq-NE-jEL" firstAttribute="top" secondItem="Fvc-fi-4hD" secondAttribute="bottom" constant="24" id="1aD-iK-fQB"/>
-                                    <constraint firstAttribute="trailing" secondItem="Fvc-fi-4hD" secondAttribute="trailing" id="3zS-gD-OAV"/>
-                                    <constraint firstItem="YVe-5z-4GD" firstAttribute="top" secondItem="Dui-K3-Pga" secondAttribute="top" constant="14" id="Eko-RH-1m4"/>
-                                    <constraint firstAttribute="trailing" secondItem="bDq-NE-jEL" secondAttribute="trailing" id="J36-8D-m37"/>
-                                    <constraint firstItem="Fvc-fi-4hD" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="JDW-Pr-e7m"/>
-                                    <constraint firstItem="Fvc-fi-4hD" firstAttribute="top" secondItem="Dui-K3-Pga" secondAttribute="top" id="LEf-XN-cew"/>
-                                    <constraint firstItem="bDq-NE-jEL" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="XgX-Um-eTS"/>
-                                    <constraint firstAttribute="trailing" secondItem="4dv-2j-TT9" secondAttribute="trailing" id="Z5Z-Cu-nce"/>
-                                    <constraint firstItem="4dv-2j-TT9" firstAttribute="top" secondItem="bDq-NE-jEL" secondAttribute="bottom" constant="8" id="lRw-Eg-VUq"/>
-                                    <constraint firstAttribute="bottom" secondItem="4dv-2j-TT9" secondAttribute="bottom" id="qgH-c3-t9Y"/>
-                                    <constraint firstItem="4dv-2j-TT9" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="rs0-o0-fZa"/>
-                                    <constraint firstItem="YVe-5z-4GD" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" constant="14" id="sm4-zb-1A3"/>
+                                    <constraint firstItem="4dv-2j-TT9" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="6Tm-sa-w2E"/>
+                                    <constraint firstAttribute="bottom" secondItem="4dv-2j-TT9" secondAttribute="bottom" id="GXx-vJ-fay"/>
+                                    <constraint firstItem="Fvc-fi-4hD" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="TC5-RP-foC"/>
+                                    <constraint firstAttribute="trailing" secondItem="4dv-2j-TT9" secondAttribute="trailing" id="TnM-yr-q1w"/>
+                                    <constraint firstItem="bDq-NE-jEL" firstAttribute="leading" secondItem="Dui-K3-Pga" secondAttribute="leading" id="YYd-6g-4J3"/>
+                                    <constraint firstItem="4dv-2j-TT9" firstAttribute="top" secondItem="bDq-NE-jEL" secondAttribute="bottom" constant="7" id="kjI-Qu-sSQ"/>
+                                    <constraint firstItem="bDq-NE-jEL" firstAttribute="top" secondItem="Fvc-fi-4hD" secondAttribute="bottom" constant="16" id="lnB-9N-J1R"/>
+                                    <constraint firstAttribute="trailing" secondItem="bDq-NE-jEL" secondAttribute="trailing" id="urI-PK-NOc"/>
+                                    <constraint firstAttribute="trailing" secondItem="Fvc-fi-4hD" secondAttribute="trailing" id="vWh-ro-1Eo"/>
+                                    <constraint firstItem="Fvc-fi-4hD" firstAttribute="top" secondItem="Dui-K3-Pga" secondAttribute="top" id="ztq-By-apT"/>
                                 </constraints>
                             </view>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="Dui-K3-Pga" firstAttribute="top" secondItem="WlS-HG-lYs" secondAttribute="top" id="DNs-Rm-XsE"/>
-                            <constraint firstItem="Dui-K3-Pga" firstAttribute="leading" secondItem="WlS-HG-lYs" secondAttribute="leading" id="JLQ-W1-9GY"/>
-                            <constraint firstItem="Dui-K3-Pga" firstAttribute="bottom" secondItem="WlS-HG-lYs" secondAttribute="bottom" constant="482" id="aKo-B0-hAH"/>
-                            <constraint firstItem="Dui-K3-Pga" firstAttribute="width" secondItem="LVW-71-Wn2" secondAttribute="width" id="rws-2w-YFH"/>
-                            <constraint firstItem="Dui-K3-Pga" firstAttribute="trailing" secondItem="WlS-HG-lYs" secondAttribute="trailing" constant="300" id="sSe-Pr-2q6"/>
+                            <constraint firstItem="Dui-K3-Pga" firstAttribute="trailing" secondItem="WlS-HG-lYs" secondAttribute="trailing" id="08R-PF-iAf"/>
+                            <constraint firstItem="Dui-K3-Pga" firstAttribute="top" secondItem="WlS-HG-lYs" secondAttribute="top" id="7Lb-2d-r50"/>
+                            <constraint firstItem="Dui-K3-Pga" firstAttribute="leading" secondItem="WlS-HG-lYs" secondAttribute="leading" id="Igu-dj-79V"/>
+                            <constraint firstItem="Dui-K3-Pga" firstAttribute="bottom" secondItem="WlS-HG-lYs" secondAttribute="bottom" id="fL0-Dw-t1O"/>
+                            <constraint firstItem="Dui-K3-Pga" firstAttribute="width" secondItem="LVW-71-Wn2" secondAttribute="width" id="nUj-6Y-dwQ"/>
                         </constraints>
                         <viewLayoutGuide key="contentLayoutGuide" id="WlS-HG-lYs"/>
                         <viewLayoutGuide key="frameLayoutGuide" id="LVW-71-Wn2"/>
@@ -99,12 +92,12 @@
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstItem="E17-rw-cau" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="3gQ-b0-VBe"/>
-                <constraint firstItem="E17-rw-cau" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="n2b-wj-Y3o"/>
-                <constraint firstAttribute="bottom" secondItem="E17-rw-cau" secondAttribute="bottom" id="pei-R1-fQf"/>
-                <constraint firstAttribute="trailing" secondItem="E17-rw-cau" secondAttribute="trailing" id="x0E-Fm-soU"/>
+                <constraint firstAttribute="bottom" secondItem="E17-rw-cau" secondAttribute="bottom" id="23M-gZ-hRy"/>
+                <constraint firstAttribute="trailing" secondItem="E17-rw-cau" secondAttribute="trailing" id="Nf1-7a-X1w"/>
+                <constraint firstItem="E17-rw-cau" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="ZEi-dE-c6X"/>
+                <constraint firstItem="E17-rw-cau" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="pa9-4q-GCx"/>
             </constraints>
-            <size key="customSize" width="232" height="386"/>
+            <size key="customSize" width="232" height="366"/>
             <connections>
                 <outlet property="contentTextView" destination="4dv-2j-TT9" id="5eo-If-TW1"/>
                 <outlet property="image" destination="Fvc-fi-4hD" id="2RN-qV-mmL"/>
@@ -113,7 +106,7 @@
                 <outlet property="scrollView" destination="E17-rw-cau" id="4js-VI-ZZX"/>
                 <outlet property="titleTextField" destination="bDq-NE-jEL" id="x3F-Fh-dMO"/>
             </connections>
-            <point key="canvasLocation" x="269.56521739130437" y="229.01785714285714"/>
+            <point key="canvasLocation" x="257.97101449275362" y="220.3125"/>
         </collectionViewCell>
     </objects>
     <resources>

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/GalleryCVC.swift
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/GalleryCVC.swift
@@ -34,6 +34,7 @@ class GalleryCVC: BorderCVC {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        indexBase.isHidden = true
     }
     
     override var isSelected: Bool {

--- a/ARtique/ARtique/Screen/Add/Cell/CVC/GalleryCVC.swift
+++ b/ARtique/ARtique/Screen/Add/Cell/CVC/GalleryCVC.swift
@@ -10,16 +10,13 @@ import SnapKit
 import Then
 
 class GalleryCVC: BorderCVC {
-    var id: String = ""
-    var isSet: Bool?
-    
     private var indexBase = UIView()
         .then {
             $0.backgroundColor = .gray4
             $0.layer.cornerRadius = 8
         }
     
-    private var selectedIndex = UILabel()
+    var selectedIndex = UILabel()
         .then {
             $0.textColor = .white
             $0.font = .AppleSDGothicSB(size: 10)
@@ -72,7 +69,6 @@ extension GalleryCVC {
 
     func configureCell(with artwork: UIImage) {
         configureCell(image: artwork, borderWidth: 3)
-        isSelected = (isSet ?? false) ? true : false
     }
     
     func setSelectedIndex(_ index: Int) {

--- a/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
@@ -244,27 +244,4 @@ extension AddExhibitionVC {
             }
         }
     }
-    
-    // TODO: ERROR 1) 해당 장수 넘을 경우 저장안되게 2) 네비바 타이틀
-    private func bindCrop() {
-        let rightBarButton = self.navigationItem.rightBarButtonItem!
-        let button = rightBarButton.customView as! UIButton
-        
-        button.rx.tap
-            .filter({ [weak self] _ in
-                self?.page == 2
-            })
-            .bind(to: artworkSelectView.preview.crop)
-            .disposed(by: bag)
-
-        button.rx.tap
-            .filter({ [weak self] _ in
-                self?.page == 2
-            })
-            .subscribe(onNext: { [weak self] _ in
-                guard let self = self else { return }
-                self.orderView.selectedPhotoCV.reloadData()
-            })
-            .disposed(by: bag)
-    }
 }

--- a/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
@@ -158,6 +158,7 @@ extension AddExhibitionVC {
         switch page {
         case 1:
             artworkSelectView.configureViewTitle()
+            artworkSelectView.setPreviewImage([0,0])
             artworkSelectView.selectedImages = exhibitionModel.artworks ?? [UIImage]()
         case 2:
             orderView.selectedPhotoCV.reloadData()

--- a/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
@@ -158,8 +158,8 @@ extension AddExhibitionVC {
         switch page {
         case 1:
             artworkSelectView.configureViewTitle()
-            artworkSelectView.maxArtworkCnt = exhibitionModel.artworkCnt ?? 0
-            artworkSelectView.selectedImages = exhibitionModel.selectedArtwork ?? [UIImage]()
+            artworkSelectView.maxArtworkCnt = exhibitionModel.gallerySize ?? 0
+            artworkSelectView.selectedImages = exhibitionModel.artworks ?? [UIImage]()
         case 2:
             orderView.selectedPhotoCV.reloadData()
             orderView.selectedPhotoCV.scrollToItem(at: [0,0], at: .top, animated: false)
@@ -177,7 +177,7 @@ extension AddExhibitionVC {
     /// 순서 조정 단계에서 테마 선택 단계로 돌아갈 경우 선택된 사진을 모두 지우는 함수
     private func deletePrevData(_ page: Int) {
         if page == 1 {
-            NewExhibition.shared.selectedArtwork?.removeAll()
+            NewExhibition.shared.artworks?.removeAll()
             artworkSelectView.galleryCV.indexPathsForSelectedItems?.forEach({
                 artworkSelectView.galleryCV.deselectItem(at: $0, animated: false)
             })
@@ -198,8 +198,8 @@ extension AddExhibitionVC {
     }
     
     @objc func removeAllExhibitionData() {
-        NewExhibition.shared.artworkCnt = nil
-        NewExhibition.shared.themeId = nil
+        NewExhibition.shared.gallerySize = nil
+        NewExhibition.shared.galleryTheme = nil
         dismiss(animated: false) {
             self.dismiss(animated: true, completion: nil)
         }
@@ -233,8 +233,8 @@ extension AddExhibitionVC {
             page -= 1
             configurePageView(page)
         } else {
-            if NewExhibition.shared.artworkCnt != nil
-                || NewExhibition.shared.themeId != nil {
+            if NewExhibition.shared.gallerySize != nil
+                || NewExhibition.shared.galleryTheme != nil {
                 popupAlert(targetView: self,
                            alertType: .removeAllExhibition,
                            leftBtnAction: #selector(removeAllExhibitionData),

--- a/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
@@ -216,14 +216,26 @@ extension AddExhibitionVC {
 // MARK: - Bind Button Action
 extension AddExhibitionVC {
     @objc func bindRightBarButton() {
-        if page != 4 {
-            page += 1
-            configurePageView(page)
-        } else {
+        switch page {
+        case 0:
+            if exhibitionModel.gallerySize != nil
+                && exhibitionModel.galleryTheme != nil {
+                page += 1
+                configurePageView(page)
+            }
+        case 1:
+            if exhibitionModel.artworks?.count == exhibitionModel.gallerySize {
+                page += 1
+                configurePageView(page)
+            }
+        case 4:
             popupAlert(targetView: self,
                        alertType: .registerExhibition,
                        leftBtnAction: #selector(dismissAlert),
                        rightBtnAction: #selector(registerExhibition))
+        default:
+            page += 1
+            configurePageView(page)
         }
     }
     

--- a/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/AddExhibitionVC.swift
@@ -158,7 +158,6 @@ extension AddExhibitionVC {
         switch page {
         case 1:
             artworkSelectView.configureViewTitle()
-            artworkSelectView.maxArtworkCnt = exhibitionModel.gallerySize ?? 0
             artworkSelectView.selectedImages = exhibitionModel.artworks ?? [UIImage]()
         case 2:
             orderView.selectedPhotoCV.reloadData()

--- a/ARtique/ARtique/Screen/Add/Xib/ArtworkSelectView.xib
+++ b/ARtique/ARtique/Screen/Add/Xib/ArtworkSelectView.xib
@@ -22,7 +22,8 @@
                 <outlet property="galleryCV" destination="F5X-Rd-VrU" id="ODH-Kk-JcQ"/>
                 <outlet property="message" destination="pGd-hl-nP6" id="9IV-TB-gZi"/>
                 <outlet property="previewBaseView" destination="gFN-B8-Oal" id="KT4-lM-qq5"/>
-                <outlet property="topConstraint" destination="ND9-MW-aey" id="IWO-aS-yJr"/>
+                <outlet property="topConstraint" destination="yvj-Mk-Zlb" id="u3f-0M-MfP"/>
+                <outlet property="verticalScrollBar" destination="SDk-Q0-haJ" id="nBC-ko-bd4"/>
                 <outlet property="viewTitle" destination="MaD-RD-r3g" id="HVM-iJ-lxl"/>
             </connections>
         </placeholder>
@@ -31,20 +32,8 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="660"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사진 선택(/)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MaD-RD-r3g">
-                    <rect key="frame" x="20" y="28" width="81" height="23"/>
-                    <fontDescription key="fontDescription" name="AppleSDGothicNeoB00" family="AppleSDGothicNeoB00" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전시할 사진을 선택할 수 있습니다" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pGd-hl-nP6">
-                    <rect key="frame" x="20" y="55" width="145" height="14"/>
-                    <fontDescription key="fontDescription" name="AppleSDGothicNeoL00" family="AppleSDGothicNeoL00" pointSize="11"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nRV-xE-iAB">
-                    <rect key="frame" x="0.0" y="424" width="375" height="236"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nRV-xE-iAB">
+                    <rect key="frame" x="0.0" y="335" width="375" height="325"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-v1-28j">
                             <rect key="frame" x="20" y="8" width="46" height="30"/>
@@ -57,8 +46,8 @@
                                 <action selector="showAlbumList:" destination="-1" eventType="touchUpInside" id="bwn-MH-OFu"/>
                             </connections>
                         </button>
-                        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="F5X-Rd-VrU">
-                            <rect key="frame" x="20" y="46" width="335" height="190"/>
+                        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="F5X-Rd-VrU">
+                            <rect key="frame" x="20" y="46" width="335" height="279"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="RFw-ft-Dsv">
                                 <size key="itemSize" width="128" height="128"/>
@@ -67,38 +56,61 @@
                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                             </collectionViewFlowLayout>
                         </collectionView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SDk-Q0-haJ">
+                            <rect key="frame" x="171.66666666666666" y="14" width="32" height="3"/>
+                            <color key="backgroundColor" red="0.72941176470588232" green="0.72941176470588232" blue="0.72941176470588232" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="32" id="0Br-1H-nK5"/>
+                                <constraint firstAttribute="height" constant="3" id="eUL-mJ-Xkp"/>
+                            </constraints>
+                        </view>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="qn0-v1-28j" firstAttribute="leading" secondItem="nRV-xE-iAB" secondAttribute="leading" constant="20" id="4wK-9R-GT0"/>
+                        <constraint firstItem="SDk-Q0-haJ" firstAttribute="top" secondItem="nRV-xE-iAB" secondAttribute="top" constant="14" id="93W-zD-ARA"/>
                         <constraint firstAttribute="bottom" secondItem="F5X-Rd-VrU" secondAttribute="bottom" id="Hph-Qg-Gxb"/>
                         <constraint firstAttribute="trailing" secondItem="F5X-Rd-VrU" secondAttribute="trailing" constant="20" id="NQa-x0-LYG"/>
+                        <constraint firstItem="SDk-Q0-haJ" firstAttribute="centerX" secondItem="nRV-xE-iAB" secondAttribute="centerX" id="Pj5-W9-NHk"/>
                         <constraint firstItem="F5X-Rd-VrU" firstAttribute="top" secondItem="qn0-v1-28j" secondAttribute="bottom" constant="8" id="SCh-yh-OGS"/>
                         <constraint firstItem="F5X-Rd-VrU" firstAttribute="leading" secondItem="nRV-xE-iAB" secondAttribute="leading" constant="20" id="hF2-CY-u0A"/>
                         <constraint firstItem="qn0-v1-28j" firstAttribute="top" secondItem="nRV-xE-iAB" secondAttribute="top" constant="8" id="xta-gl-w3N"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFN-B8-Oal">
-                    <rect key="frame" x="20" y="89" width="335" height="335"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gFN-B8-Oal" userLabel="previewBaseView">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="335"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전시할 사진을 선택할 수 있습니다" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pGd-hl-nP6">
+                            <rect key="frame" x="20" y="55" width="145" height="14"/>
+                            <fontDescription key="fontDescription" name="AppleSDGothicNeoL00" family="AppleSDGothicNeoL00" pointSize="11"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사진 선택(/)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MaD-RD-r3g">
+                            <rect key="frame" x="20" y="28" width="81" height="23"/>
+                            <fontDescription key="fontDescription" name="AppleSDGothicNeoB00" family="AppleSDGothicNeoB00" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" secondItem="gFN-B8-Oal" secondAttribute="height" multiplier="1:1" id="Fwn-3l-o9O"/>
+                        <constraint firstItem="pGd-hl-nP6" firstAttribute="top" secondItem="MaD-RD-r3g" secondAttribute="bottom" constant="4" id="MJp-GS-KAz"/>
+                        <constraint firstItem="pGd-hl-nP6" firstAttribute="leading" secondItem="gFN-B8-Oal" secondAttribute="leading" constant="20" id="UoW-Nh-yvs"/>
+                        <constraint firstItem="MaD-RD-r3g" firstAttribute="top" secondItem="gFN-B8-Oal" secondAttribute="top" constant="28" id="Ynb-xC-Nbu"/>
+                        <constraint firstItem="MaD-RD-r3g" firstAttribute="leading" secondItem="gFN-B8-Oal" secondAttribute="leading" constant="20" id="dJ2-wk-fcc"/>
                     </constraints>
                 </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="gFN-B8-Oal" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="9YS-n8-al5"/>
                 <constraint firstAttribute="trailing" secondItem="nRV-xE-iAB" secondAttribute="trailing" id="Bvr-B9-r7s"/>
+                <constraint firstAttribute="trailing" secondItem="gFN-B8-Oal" secondAttribute="trailing" id="IAO-Pg-zHZ"/>
                 <constraint firstItem="nRV-xE-iAB" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="JKE-Zi-WTs"/>
-                <constraint firstItem="gFN-B8-Oal" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="89" id="ND9-MW-aey"/>
-                <constraint firstItem="pGd-hl-nP6" firstAttribute="top" secondItem="MaD-RD-r3g" secondAttribute="bottom" constant="4" id="P7f-9l-XaP"/>
-                <constraint firstAttribute="trailing" secondItem="gFN-B8-Oal" secondAttribute="trailing" constant="20" id="TQr-yb-Ml7"/>
-                <constraint firstItem="nRV-xE-iAB" firstAttribute="top" secondItem="gFN-B8-Oal" secondAttribute="bottom" id="eV0-96-wRh"/>
-                <constraint firstItem="MaD-RD-r3g" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="ggZ-7R-l2R"/>
+                <constraint firstItem="nRV-xE-iAB" firstAttribute="top" secondItem="gFN-B8-Oal" secondAttribute="bottom" id="K1i-4S-tQl"/>
                 <constraint firstAttribute="bottom" secondItem="nRV-xE-iAB" secondAttribute="bottom" id="iWS-CS-Czq"/>
-                <constraint firstItem="pGd-hl-nP6" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="sSf-Gq-T7B"/>
-                <constraint firstItem="MaD-RD-r3g" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="28" id="wP6-8A-Fpw"/>
+                <constraint firstItem="gFN-B8-Oal" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ucn-En-ljQ"/>
+                <constraint firstItem="gFN-B8-Oal" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="yvj-Mk-Zlb"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/ARtique/ARtique/Screen/Add/Xib/PostExplainView.xib
+++ b/ARtique/ARtique/Screen/Add/Xib/PostExplainView.xib
@@ -18,7 +18,6 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PostExplainView" customModule="ARtique" customModuleProvider="target">
             <connections>
                 <outlet property="artworkExplainCV" destination="sL0-F2-AhQ" id="ncf-qn-jsf"/>
-                <outlet property="baseSV" destination="u5E-2c-MDy" id="t1l-9W-ET1"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -38,45 +37,27 @@
                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u5E-2c-MDy">
-                    <rect key="frame" x="0.0" y="86" width="375" height="574"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vrG-S7-qyu">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
-                            <subviews>
-                                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="sL0-F2-AhQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gwc-G9-Xqb">
-                                        <size key="itemSize" width="128" height="128"/>
-                                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                    </collectionViewFlowLayout>
-                                </collectionView>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        </view>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="vrG-S7-qyu" firstAttribute="top" secondItem="gHp-np-39x" secondAttribute="top" id="LeJ-06-sCM"/>
-                        <constraint firstItem="vrG-S7-qyu" firstAttribute="leading" secondItem="gHp-np-39x" secondAttribute="leading" id="buB-MX-QDL"/>
-                        <constraint firstItem="vrG-S7-qyu" firstAttribute="trailing" secondItem="gHp-np-39x" secondAttribute="trailing" id="en0-HK-HX2"/>
-                        <constraint firstItem="vrG-S7-qyu" firstAttribute="bottom" secondItem="gHp-np-39x" secondAttribute="bottom" id="pGu-1V-ygG"/>
-                        <constraint firstItem="vrG-S7-qyu" firstAttribute="width" secondItem="EHv-iA-fh9" secondAttribute="width" id="qPv-Kf-Xdg"/>
-                    </constraints>
-                    <viewLayoutGuide key="contentLayoutGuide" id="gHp-np-39x"/>
-                    <viewLayoutGuide key="frameLayoutGuide" id="EHv-iA-fh9"/>
-                </scrollView>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="sL0-F2-AhQ">
+                    <rect key="frame" x="0.0" y="89" width="375" height="571"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gwc-G9-Xqb">
+                        <size key="itemSize" width="128" height="128"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
+                <constraint firstAttribute="trailing" secondItem="sL0-F2-AhQ" secondAttribute="trailing" id="5Gs-er-rj0"/>
                 <constraint firstItem="t9R-oT-0Il" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="Abo-f8-5ss"/>
                 <constraint firstItem="Yvo-8q-Zba" firstAttribute="top" secondItem="t9R-oT-0Il" secondAttribute="bottom" constant="4" id="Shq-PL-JmO"/>
                 <constraint firstItem="Yvo-8q-Zba" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="dhD-Sc-EBu"/>
+                <constraint firstAttribute="bottom" secondItem="sL0-F2-AhQ" secondAttribute="bottom" id="hHo-Yu-id0"/>
+                <constraint firstItem="sL0-F2-AhQ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="89" id="kVR-F8-MUP"/>
                 <constraint firstItem="t9R-oT-0Il" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="28" id="mUT-D2-qsz"/>
+                <constraint firstItem="sL0-F2-AhQ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="xMW-dk-ed6"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/ARtique/ARtique/Screen/Add/Xib/PostExplainView.xib
+++ b/ARtique/ARtique/Screen/Add/Xib/PostExplainView.xib
@@ -38,8 +38,11 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="sL0-F2-AhQ">
-                    <rect key="frame" x="0.0" y="89" width="375" height="571"/>
+                    <rect key="frame" x="0.0" y="69" width="375" height="513"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="513" id="eeV-Lt-ze3"/>
+                    </constraints>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gwc-G9-Xqb">
                         <size key="itemSize" width="128" height="128"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -54,8 +57,7 @@
                 <constraint firstItem="t9R-oT-0Il" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="Abo-f8-5ss"/>
                 <constraint firstItem="Yvo-8q-Zba" firstAttribute="top" secondItem="t9R-oT-0Il" secondAttribute="bottom" constant="4" id="Shq-PL-JmO"/>
                 <constraint firstItem="Yvo-8q-Zba" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="dhD-Sc-EBu"/>
-                <constraint firstAttribute="bottom" secondItem="sL0-F2-AhQ" secondAttribute="bottom" id="hHo-Yu-id0"/>
-                <constraint firstItem="sL0-F2-AhQ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="89" id="kVR-F8-MUP"/>
+                <constraint firstItem="sL0-F2-AhQ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="69" id="kVR-F8-MUP"/>
                 <constraint firstItem="t9R-oT-0Il" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="28" id="mUT-D2-qsz"/>
                 <constraint firstItem="sL0-F2-AhQ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="xMW-dk-ed6"/>
             </constraints>

--- a/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
@@ -97,7 +97,7 @@ extension ArtworkSelectView {
     
     func configureViewTitle() {
         //TODO: - 데이터 구조 수정 후 수정
-        viewTitle.text = "사진선택 (\(selectedImageIds.count)/\(exhibitionModel.artworkCnt ?? 0))"
+        viewTitle.text = "사진선택 (\(selectedImageIds.count)/\(exhibitionModel.gallerySize ?? 0))"
     }
     
     private func configurePreview() {
@@ -197,7 +197,7 @@ extension ArtworkSelectView {
                 guard let self = self else { return }
                 if !self.isFirstSelection {
                     self.selectedImages.append(image ?? UIImage())
-                    self.exhibitionModel.selectedArtwork = self.selectedImages
+                    self.exhibitionModel.artworks = self.selectedImages
                 }
                 // TODO: - ERROR
                 self.isFirstSelection = false
@@ -286,7 +286,7 @@ extension ArtworkSelectView: UICollectionViewDelegate {
         cell.isSet = false
         selectedImages.remove(at: selectedImageIds.firstIndex(of: cell.id)!)
         selectedImageIds.remove(at: selectedImageIds.firstIndex(of: cell.id)!)
-        exhibitionModel.selectedArtwork = selectedImages
+        exhibitionModel.artworks = selectedImages
         spiner.stopAnimating()
         configureViewTitle()
     }

--- a/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
@@ -284,6 +284,13 @@ extension ArtworkSelectView: UICollectionViewDelegate {
         exhibitionModel.artworks = selectedImages
         spiner.stopAnimating()
         configureViewTitle()
+        
+        collectionView.indexPathsForSelectedItems?.forEach {
+            let restCell = collectionView.cellForItem(at: $0) as! GalleryCVC
+            if Int(restCell.selectedIndex.text!)! > Int(cell.selectedIndex.text!)! {
+                restCell.selectedIndex.text = "\(Int(restCell.selectedIndex.text!)! - 1)"
+            }
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {

--- a/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/ArtworkSelectView.swift
@@ -303,7 +303,7 @@ extension ArtworkSelectView: UICollectionViewDataSource {
             
             guard let items = collectionView.indexPathsForSelectedItems else { return }
             if items.contains(indexPath) {
-                cell.setSelectedIndex((self.indexArr.firstIndex(of: indexPath.row)!) + 1)
+                cell.setSelectedIndex((self.indexArr.firstIndex(of: indexPath.row) ?? 0) + 1)
             }
         }
         

--- a/ARtique/ARtique/Screen/Add/XibController/ExhibitionExplainView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/ExhibitionExplainView.swift
@@ -106,7 +106,7 @@ extension ExhibitionExplainView {
         exhibitionExplainTextView.rx.text.orEmpty
             .withUnretained(self)
             .subscribe(onNext: { owner, explain in
-                owner.exhibitionModel.exhibitionExplain = explain
+                owner.exhibitionModel.description = explain
                 owner.setTextViewMaxCnt(explain.count)
             })
             .disposed(by: bag)
@@ -114,7 +114,7 @@ extension ExhibitionExplainView {
         tagCV.rx.itemDeselected
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                owner.exhibitionModel.tagId = owner.selectedTags()
+                owner.exhibitionModel.tag = owner.selectedTags()
             })
             .disposed(by: bag)
         
@@ -139,11 +139,11 @@ extension ExhibitionExplainView {
             .subscribe(onNext: { owner, index in
                 switch collectionView {
                 case owner.categoryCV:
-                    owner.exhibitionModel.categoryId = index.row
+                    owner.exhibitionModel.category = index.row
                 case owner.phosterCV:
-                    owner.exhibitionModel.phosterId = index.row
+                    owner.exhibitionModel.phosterTheme = index.row
                 case owner.tagCV:
-                    owner.exhibitionModel.tagId = owner.selectedTags()
+                    owner.exhibitionModel.tag = owner.selectedTags()
                 default:
                     break
                 }
@@ -190,7 +190,7 @@ extension ExhibitionExplainView: UICollectionViewDataSource {
             roundCell.configureCell(with: CategoryType.allCases[indexPath.row].categoryTitle, fontSize: 14)
             return roundCell
         case phosterCV:
-            phosterCell.configureCell(image: NewExhibition.shared.selectedArtwork?.first ?? UIImage(),
+            phosterCell.configureCell(image: NewExhibition.shared.artworks?.first ?? UIImage(),
                                       borderWidth: 4)
             return phosterCell
         default:

--- a/ARtique/ARtique/Screen/Add/XibController/OrderView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/OrderView.swift
@@ -70,10 +70,8 @@ extension OrderView {
                 collectionView.deleteItems(at: [sourceIndexPath])
                 collectionView.insertItems(at: [destinationIndexPath])
                 
-            }, completion: {_ in
-                DispatchQueue.main.async {
-                    collectionView.reloadData()
-                }
+            }, completion: { _ in
+                self.selectedPhotoCV.reloadItems(at: self.selectedPhotoCV.indexPathsForVisibleItems)
             })
             coordinator.drop(item.dragItem, toItemAt : destinationIndexPath)
         }

--- a/ARtique/ARtique/Screen/Add/XibController/OrderView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/OrderView.swift
@@ -58,8 +58,8 @@ extension OrderView {
     private func reorderItems(coordinator : UICollectionViewDropCoordinator, destinationIndexPath : IndexPath, collectionView : UICollectionView) {
         if let item = coordinator.items.first, let sourceIndexPath = item.sourceIndexPath {
             collectionView.performBatchUpdates({
-                let item = exhibitionModel.selectedArtwork?.remove(at: sourceIndexPath.row) ?? UIImage()
-                exhibitionModel.selectedArtwork?.insert(item, at: destinationIndexPath.row)
+                let item = exhibitionModel.artworks?.remove(at: sourceIndexPath.row) ?? UIImage()
+                exhibitionModel.artworks?.insert(item, at: destinationIndexPath.row)
                 
                 guard let title = exhibitionModel.artworkTitle?.remove(at: sourceIndexPath.row) else { return }
                 exhibitionModel.artworkTitle?.insert(title, at: destinationIndexPath.row)
@@ -83,12 +83,12 @@ extension OrderView {
 // MARK: - UICollectionViewDataSource
 extension OrderView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        NewExhibition.shared.selectedArtwork?.count ?? 0
+        NewExhibition.shared.artworks?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Identifiers.galleryCVC, for: indexPath) as? GalleryCVC else { return UICollectionViewCell() }
-        cell.configureCell(with: exhibitionModel.selectedArtwork?[indexPath.row] ?? UIImage())
+        cell.configureCell(with: exhibitionModel.artworks?[indexPath.row] ?? UIImage())
         cell.setSelectedIndex(indexPath.row + 1)
         return cell
     }

--- a/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
@@ -9,24 +9,24 @@ import UIKit
 import SnapKit
 
 class PostExplainView: UIView {
-    @IBOutlet weak var baseSV: UIScrollView!
     @IBOutlet weak var artworkExplainCV: UICollectionView!
     
+    var isKeyboardVisible = false
     var currentIndex:CGFloat = 0
     let cellWidth: CGFloat = 300
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setContentView()
-        configureLayout()
         configureCV()
+        setNotification()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setContentView()
-        configureLayout()
         configureCV()
+        setNotification()
     }
 }
 
@@ -56,17 +56,26 @@ extension PostExplainView {
             layout.scrollDirection = .horizontal
         }
     }
+}
+// MARK: - Custom Methods
+extension PostExplainView {
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollToFirstResponder), name: .changeFirstResponder, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
     
-    private func configureLayout() {
-        baseSV.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalToSuperview().offset(89)
-        }
-        
-        artworkExplainCV.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.height.equalTo(UIScreen.main.bounds.height - 170)
-        }
+    @objc func keyboardWillShow(notification: NSNotification) {
+        isKeyboardVisible = true
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        isKeyboardVisible = false
+    }
+    
+    @objc func scrollToFirstResponder(_ notification: Notification) {
+        guard let index = notification.object as? Int else { return }
+        artworkExplainCV.scrollToItem(at: [0, index], at: .left, animated: true)
     }
 }
 
@@ -121,5 +130,11 @@ extension PostExplainView: UICollectionViewDelegate {
         offset = CGPoint(x: roundedIndex * cellWidthIncludeSpacing - scrollView.contentInset.left,
                          y: scrollView.contentInset.top)
         targetContentOffset.pointee = offset
+        
+        if isKeyboardVisible {
+            guard let cell = artworkExplainCV.cellForItem(at: [0, Int(currentIndex)]) as? ArtworkExplainCVC else { return }
+            
+            cell.titleTextField.becomeFirstResponder()
+        }
     }
 }

--- a/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
@@ -67,10 +67,22 @@ extension PostExplainView {
     
     @objc func keyboardWillShow(notification: NSNotification) {
         isKeyboardVisible = true
+        UIView.animate(withDuration: 0.3) {
+            self.artworkExplainCV.snp.updateConstraints {
+                $0.top.equalToSuperview()
+            }
+            self.layoutIfNeeded()
+        }
     }
     
     @objc func keyboardWillHide(notification: NSNotification) {
         isKeyboardVisible = false
+        UIView.animate(withDuration: 0.3) {
+            self.artworkExplainCV.snp.updateConstraints {
+                $0.top.equalToSuperview().offset(69)
+            }
+            self.layoutIfNeeded()
+        }
     }
     
     @objc func scrollToFirstResponder(_ notification: Notification) {

--- a/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/PostExplainView.swift
@@ -73,7 +73,7 @@ extension PostExplainView {
 // MARK: - UICollectionViewDataSource
 extension PostExplainView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        NewExhibition.shared.selectedArtwork?.count ?? 0
+        NewExhibition.shared.artworks?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/ARtique/ARtique/Screen/Add/XibController/ThemeView.swift
+++ b/ARtique/ARtique/Screen/Add/XibController/ThemeView.swift
@@ -130,11 +130,11 @@ extension ThemeView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch collectionView {
         case cntCV:
-            exhibitionModel.artworkCnt = setGalleryCount(indexPath.row)
-            exhibitionModel.artworkTitle = [String](repeating: "", count: exhibitionModel.artworkCnt!)
-            exhibitionModel.artworkExplain = [String](repeating: "", count: exhibitionModel.artworkCnt!)
+            exhibitionModel.gallerySize = setGalleryCount(indexPath.row)
+            exhibitionModel.artworkTitle = [String](repeating: "", count: exhibitionModel.gallerySize!)
+            exhibitionModel.artworkExplain = [String](repeating: "", count: exhibitionModel.gallerySize!)
         default:
-            exhibitionModel.themeId = indexPath.row
+            exhibitionModel.galleryTheme = indexPath.row
         }
     }
 }

--- a/ARtique/Podfile
+++ b/ARtique/Podfile
@@ -16,6 +16,7 @@ target 'ARtique' do
   # Rx
   pod 'RxSwift', '< 6.2.0'
   pod 'RxCocoa', '< 6.2.0'
+  pod "RxGesture"
 
   # Kakaotalk
   pod 'KakaoSDKUser', '~> 2.8.6'

--- a/ARtique/Podfile.lock
+++ b/ARtique/Podfile.lock
@@ -49,6 +49,7 @@ DEPENDENCIES:
   - Moya
   - PhotoCropper
   - RxCocoa (< 6.2.0)
+  - RxGesture
   - RxSwift (< 6.2.0)
   - SnapKit (~> 5.0.1)
   - Tabman (~> 2.9)
@@ -89,6 +90,6 @@ SPEC CHECKSUMS:
   Tabman: 792ac76fd1ec95af175c93db880a3c47cabedc91
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: 84530d9357e0c04858f16172eab9fe11b1f7cf09
+PODFILE CHECKSUM: 30e99017eb152720c5b98f67fc163cb7099755a1
 
 COCOAPODS: 1.11.2

--- a/ARtique/Pods/Manifest.lock
+++ b/ARtique/Pods/Manifest.lock
@@ -49,6 +49,7 @@ DEPENDENCIES:
   - Moya
   - PhotoCropper
   - RxCocoa (< 6.2.0)
+  - RxGesture
   - RxSwift (< 6.2.0)
   - SnapKit (~> 5.0.1)
   - Tabman (~> 2.9)
@@ -89,6 +90,6 @@ SPEC CHECKSUMS:
   Tabman: 792ac76fd1ec95af175c93db880a3c47cabedc91
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: 84530d9357e0c04858f16172eab9fe11b1f7cf09
+PODFILE CHECKSUM: 30e99017eb152720c5b98f67fc163cb7099755a1
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 🌈 PR 요약
사진 선택 뷰
- 선택 해제 에러 해결 및 해제 시 남은 cell 재 넘버링 추가
- 이미지 스크롤, 확대 및 축소 완료 시 이미지 crop 되도록 추가
- 이미지 로딩 중 해당 cell 재선택시 새로고침
- 테마 및 개수 선택 화면, 이미지 선택화면

설명 입력 뷰
- 키보드 show/hide에 따른 cell 개별 스크롤 구조 수정
- 좌우 스크롤 시 firstResponder 바뀌도록 추가

## 📌 변경 사항
pod "RxGesture" 추가했습니다

## 📸 ScreenShot
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/61379671/168463431-7dc5a2a9-e71e-4bbe-8d8f-f8ccf8917926.gif)
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/61379671/168463435-f6c14758-059d-4a72-b407-e3f7fc4333a9.gif)



#### Linked Issue
close #60 
