### PR TITLE
Chore/#122 home paging error

### DIFF
--- a/ARtique/ARtique/Network/APIManagers/MypageAPI.swift
+++ b/ARtique/ARtique/Network/APIManagers/MypageAPI.swift
@@ -57,4 +57,32 @@ extension MypageAPI {
             }
         }
     }
+    
+    func getMyExhibition(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        provider.request(.getMyExhibition) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.judgeStatus(type: [ExhibitionModel].self, by: statusCode, data))
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    
+    func getBookmarkedExhibition(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        provider.request(.getBookmarkedExhibition) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.judgeStatus(type: [ExhibitionModel].self, by: statusCode, data))
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }

--- a/ARtique/ARtique/Network/APIModels/Models/Mypage/MypageModel.swift
+++ b/ARtique/ARtique/Network/APIModels/Models/Mypage/MypageModel.swift
@@ -9,6 +9,8 @@ import Foundation
 
 struct MypageModel: Codable {
     let user: ArtistProfile
+    let myExhibitionCount: Int
     let myExhibition: [ExhibitionModel]
+    let myBookmarkCount: Int
     let myBookmarkedData : [ExhibitionModel]
 }

--- a/ARtique/ARtique/Network/MoyaTarget/MypageService.swift
+++ b/ARtique/ARtique/Network/MoyaTarget/MypageService.swift
@@ -12,6 +12,8 @@ enum MypageService {
     case getMypageData
     case editProfile(artist: ArtistModel)
     case getArtistProfile(artistID: Int)
+    case getMyExhibition
+    case getBookmarkedExhibition
 }
 
 extension MypageService: TargetType {
@@ -27,12 +29,16 @@ extension MypageService: TargetType {
             return "/mypage/profile"
         case .getArtistProfile(let artistID):
             return "/artist/\(artistID)"
+        case .getMyExhibition:
+            return "/mypage/exhibition"
+        case .getBookmarkedExhibition:
+            return "/mypage/bookmark"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getMypageData, .getArtistProfile:
+        case .getMypageData, .getArtistProfile, .getMyExhibition, .getBookmarkedExhibition:
             return .get
         case .editProfile:
             return .put
@@ -41,7 +47,7 @@ extension MypageService: TargetType {
     
     var task: Task {
         switch self {
-        case .getMypageData, .getArtistProfile:
+        case .getMypageData, .getArtistProfile, .getMyExhibition, .getBookmarkedExhibition:
             return .requestPlain
         case .editProfile(let artist):
             var multipartData = [MultipartFormData]()

--- a/ARtique/ARtique/Screen/Add/Controller/ThemeVC.swift
+++ b/ARtique/ARtique/Screen/Add/Controller/ThemeVC.swift
@@ -88,22 +88,13 @@ extension ThemeVC: UICollectionViewDelegateFlowLayout {
         20
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        switch collectionView {
-        case cntCV:
-            return 13
-        default:
-            return 15
-        }
-    }
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         switch collectionView {
         case cntCV:
-            return CGSize(width: (UIScreen.main.bounds.width - 40 - 26) / 3,
+            return CGSize(width: collectionView.frame.width / 3.2,
                           height: collectionView.frame.height)
         default:
-            let cellWidth = (collectionView.frame.width - 15) / 2
+            let cellWidth = collectionView.frame.width / 2.1
             return CGSize(width: cellWidth,
                           height: cellWidth + 23)
         }

--- a/ARtique/ARtique/Screen/Add/Storyboard/ThemeVC.storyboard
+++ b/ARtique/ARtique/Screen/Add/Storyboard/ThemeVC.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/ARtique/ARtique/Screen/Home/Cell/TVC/HomeHorizontalTVC.swift
+++ b/ARtique/ARtique/Screen/Home/Cell/TVC/HomeHorizontalTVC.swift
@@ -94,13 +94,14 @@ extension HomeHorizontalTVC: UICollectionViewDataSource {
         ? cell.configureCell(exhibitionData?.forArtiExhibition[indexPath.row] ?? ExhibitionModel())
         : cell.configureCell(exhibitionData?.popularExhibition[indexPath.row] ?? ExhibitionModel())
         
-        /// 처음 로드될 때 현재 셀 아니면 사이즈 줄이기  -> scrollViewDidScroll이랑 중복, 수정 요망
-        if indexPath.row != 0 {
+        /// 처음 로드될 때 현재 셀 아니면 사이즈 줄이기
+        if indexPath.row != Int(currentIndex) {
             animateZoomforCellremove(zoomCell: cell)
         }
         return cell
     }
 }
+
 // MARK: UICollectionViewDelegate
 extension HomeHorizontalTVC: UICollectionViewDelegate{
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -164,6 +165,7 @@ extension HomeHorizontalTVC: UICollectionViewDelegate{
         }
     }
 }
+
 // MARK: UICollectionViewDelegateFlowLayout
 extension HomeHorizontalTVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/ARtique/ARtique/Screen/Home/Controller/HomeListVC.swift
+++ b/ARtique/ARtique/Screen/Home/Controller/HomeListVC.swift
@@ -28,6 +28,7 @@ class HomeListVC: BaseVC {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        LoadingHUD.show()
         getExhibitionList(categoryID: categoryType?.categoryId ?? 1)
         configureTopLayout()
     }
@@ -91,7 +92,6 @@ extension HomeListVC{
 // MARK: - Network
 extension HomeListVC {
     private func getExhibitionList(categoryID: Int) {
-        LoadingHUD.show()
         HomeAPI.shared.getHomeExhibitionList(categoryID: categoryID) { [weak self] networkResult in
             switch networkResult {
             case .success(let list):

--- a/ARtique/ARtique/Screen/Mypage/Controller/MypageVC.swift
+++ b/ARtique/ARtique/Screen/Mypage/Controller/MypageVC.swift
@@ -23,6 +23,8 @@ class MypageVC: BaseVC {
     var artistData: ArtistProfile?
     var registerData: [ExhibitionModel]?
     var bookmarkData: [ExhibitionModel]?
+    var registeredCnt: Int?
+    var bookmarkedCnt: Int?
     var ticketCnt: Int?
     
     override func viewDidLoad() {
@@ -100,7 +102,7 @@ extension MypageVC {
     
     private func configureExhibitionCntBtn() {
         registeredExhibitionBtn.title.text = "등록 전시 수"
-        registeredExhibitionBtn.exhibitionCnt.text = "\(registerData?.count ?? 0)"
+        registeredExhibitionBtn.exhibitionCnt.text = "\(registeredCnt ?? 0)"
         
         ticketBtn.title.text = "내 티켓 수"
         ticketBtn.exhibitionCnt.text = "\(ticketCnt ?? 0)"
@@ -170,6 +172,8 @@ extension MypageVC {
                     self.registerData = data.myExhibition
                     self.bookmarkData = data.myBookmarkedData
                     self.ticketCnt = data.user.ticketCount
+                    self.registeredCnt = data.myExhibitionCount
+                    self.bookmarkedCnt = data.myBookmarkCount
                     self.artistData = data.user
                     self.setUserData(artist: data.user)
                     self.configureExhibitionCntBtn()
@@ -185,6 +189,58 @@ extension MypageVC {
                 } else if res is Bool {
                     self.requestRenewalToken() { _ in
                         self.getMypageData()
+                    }
+                }
+            default:
+                LoadingHUD.hide()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    private func getMyExhibition() {
+        MypageAPI.shared.getMyExhibition { [weak self] networkResult in
+            guard let self = self else { return }
+            switch networkResult {
+            case .success(let data):
+                if let data = data as? [ExhibitionModel] {
+                    self.showExhibitionListVC(title: "등록한 전시 \(self.registeredCnt ?? 0)", data: data)
+                    LoadingHUD.hide()
+                }
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    LoadingHUD.hide()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.requestRenewalToken() { _ in
+                        self.getMyExhibition()
+                    }
+                }
+            default:
+                LoadingHUD.hide()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    private func getBookmarkedExhibition() {
+        MypageAPI.shared.getBookmarkedExhibition { [weak self] networkResult in
+            guard let self = self else { return }
+            switch networkResult {
+            case .success(let data):
+                if let data = data as? [ExhibitionModel] {
+                    self.showExhibitionListVC(title: "북마크한 전시 \(self.bookmarkedCnt ?? 0)", data: data)
+                    LoadingHUD.hide()
+                }
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    LoadingHUD.hide()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.requestRenewalToken() { _ in
+                        self.getBookmarkedExhibition()
                     }
                 }
             default:
@@ -212,15 +268,15 @@ extension MypageVC: UITableViewDataSource {
         switch indexPath.row {
         case 0:
             !(registerData?.isEmpty ?? true)
-            ? titleCell.configureCell("등록한 전시", registerData?.count ?? 0)
-            : titleCell.configureCell("북마크한 전시", bookmarkData?.count ?? 0)
+            ? titleCell.configureCell("등록한 전시", registeredCnt ?? 0)
+            : titleCell.configureCell("북마크한 전시", bookmarkedCnt ?? 0)
             return titleCell
         case 1:
             exhibitionCell.exhibitionData = !(registerData?.isEmpty ?? true)
             ? registerData : bookmarkData
             return exhibitionCell
         case 2:
-            titleCell.configureCell("북마크한 전시", bookmarkData?.count ?? 0)
+            titleCell.configureCell("북마크한 전시", bookmarkedCnt ?? 0)
             return titleCell
         case 3:
             exhibitionCell.exhibitionData = bookmarkData
@@ -238,9 +294,11 @@ extension MypageVC: UITableViewDelegate {
         
         switch cell.exhibitionType.text {
         case "등록한 전시":
-            showExhibitionListVC(title: "등록한 전시 \(registerData?.count ?? 0)", data: registerData ?? [ExhibitionModel]())
+            LoadingHUD.show()
+            getMyExhibition()
         case "북마크한 전시":
-            showExhibitionListVC(title: "북마크한 전시 \(bookmarkData?.count ?? 0)", data: bookmarkData ?? [ExhibitionModel]())
+            LoadingHUD.show()
+            getBookmarkedExhibition()
         default:
             break
         }

--- a/ARtique/ARtique/Screen/Shared/Alert.storyboard
+++ b/ARtique/ARtique/Screen/Shared/Alert.storyboard
@@ -83,7 +83,7 @@
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.33554946192052981" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="31x-F8-OjR" secondAttribute="trailing" constant="52" id="iZk-7J-DeV"/>
                             <constraint firstItem="31x-F8-OjR" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="52" id="t3V-ce-qIA"/>


### PR DESCRIPTION
## 🌈 PR 요약
홈화면 ㅇㅇ아띠를 위한 전시, 인기 전시 부분에서 카테고리 전환 시 포커싱 오류가 있어서
collectionViewCell의 초기 포커싱값을 paging 된 마지막 값으로 수정하였습니다.

## 📌 변경 사항
- 홈화면에서 loading.show가 네트워킹 함수 내부에 들어있고 requestErr 부분에서 네트워킹 함수가 재귀로 호출되어
어플 시작 시 로딩이 계속 다시 시작되는 오류가 있어 해당 부분을 함수 호출 부분으로 옮겼습니다!
- AlertVC backgroundColor 투명도 70으로 변경하였습니다.
- 테마 선택 화면 cell spacing 값을 수정하여 iphone max에서 개수 선택 깨지는 부분 수정하였습니다.
- 기존 마이페이지에서 받아온 데이터로 등록, 북마크한 전시 페이지의 데이터를 연결하던 방법에서 상세 페이지로 이동할 때 데이터를 새로 받아오도록 수정하였습니다.

## 📸 ScreenShot


#### Linked Issue
close #122 
